### PR TITLE
#2 클립보드 문제해결과 몇 가지를 수정하였습니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/jybaek/translate-in-terminal.git
 cd translate-in-terminal
 # pip install wheel
 python setup.py bdist_wheel
-pip install dist/ranslatebot-1.0.0-py3-none-any.whl -I # slush or back-slush
+pip install dist/translatebot-1.0.0-py3-none-any.whl -I # slush or back-slush
 ```
 
 ## Usage
@@ -68,7 +68,7 @@ $
 ### Help Message
 ```bash
 $ translate --help
-usage: translate [-h] [--clipboard] [--dumb] [data [data ...]]
+usage: translate.py [-h] [-c] [-d] [data [data ...]]
 
 Terminal translator
 
@@ -77,6 +77,7 @@ positional arguments:
 
 optional arguments:
   -h, --help       show this help message and exit
-  --clipboard, -c  Using clipboard data.
-  --dumb, -d       No showing output data.
+  -c, --clipboard  Using clipboard data.
+  -d, --dumb       No showing output data.
+
 ```

--- a/translate/translate.py
+++ b/translate/translate.py
@@ -4,28 +4,25 @@ from googletrans import Translator
 
 LANG = {'ko': 'en', 'en': 'ko'}
 
+try:
+    pyperclip.paste()
+    CLIPBOARD_MESSAGE = 'Using clipboard data.'
+except pyperclip.PyperclipException:
+    CLIPBOARD_MESSAGE = """
+    This error should only appear on Linux (not Windows or Mac). 
+    You can fix this by installing one of the copy/paste mechanisms:
+    
+    sudo apt-get install xsel to install the xsel utility.
+    sudo apt-get install xclip to install the xclip utility.
+    pip install gtk to install the gtk Python module.
+    pip install PyQt4 to install the PyQt4 Python module.
+    """
+    del pyperclip
 
-def main():
-    # Argparse Setting
-    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS,
-                                     description='Terminal translator')
-    parser.add_argument('-c', '--clipboard', action='store_true',
-                        default=False, help='Using clipboard data.')
-    parser.add_argument('data', default=None, nargs='*',
-                        help='The text to query.')
-    parser.add_argument('-d', '--dumb', action='store_true',
-                        default=False, help='No showing output data.')
-    args = parser.parse_args()
 
-    # Getting the text messages at which user selected
-    text = args.data
-    if args.clipboard:
-        text = [pyperclip.paste()]
+def translate(text: list):
     text = ' '.join(text)
     text = text.replace('\n', ' ')
-
-    if not text:
-        raise parser.error('No text to translate.')
 
     # Translating each text message
     translator = Translator()
@@ -33,10 +30,63 @@ def main():
     if lang not in ('ko', 'en'):
         raise ValueError('Unknown language')
     data = translator.translate(text, dest=LANG[lang]).text
-    pyperclip.copy(data)
+    return data
+
+
+def clipboard():
+    if 'pyperclip' not in globals():
+        raise argparse.ArgumentError(None, CLIPBOARD_MESSAGE)
+    text = pyperclip.paste()
+    return [text]
+
+
+class TranslateAction(argparse._StoreAction):
+    def __init__(self, option_strings, dest, nargs=None, const=None,
+                 default=None, type=None, choices=None, required=False,
+                 help=None, metavar=None ):
+
+        super(TranslateAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=nargs,
+            const=const,
+            default=default,
+            type=type,
+            choices=choices,
+            required=required,
+            help=help,
+            metavar=metavar)
+
+    def __call__(self, parser:argparse.ArgumentParser, namespace, values, option_string=None):
+        text = values
+        if 'clipboard' in namespace and getattr(namespace, 'clipboard'):
+            text = clipboard()
+        values = translate(text)
+        setattr(namespace, self.dest, values)
+
+
+def main():
+    # Argparse Setting
+    parser = argparse.ArgumentParser(description='Terminal translator',
+                                     argument_default=argparse.SUPPRESS)
+    parser.register('action', 'translate', TranslateAction)
+    parser.add_argument('-c', '--clipboard', action='store_true',
+                         help=CLIPBOARD_MESSAGE)
+    parser.add_argument('-d', '--dumb', action='store_true', default=False,
+                         help='No showing output data.')
+    parser.add_argument('data', nargs='*', action='translate', default=None,
+                        help='The text to query.')
+    args = parser.parse_args()
+
+    # Getting the text messages at which user selected
+    if not args.data:
+        raise parser.error('No text to translate.')
+
+    if 'pyperclip' in globals():
+        pyperclip.copy(args.data)
 
     if not args.dumb:
-        print(data)
+        print(args.data)
 
 
 if __name__ == '__main__':

--- a/translate/translate.py
+++ b/translate/translate.py
@@ -9,11 +9,11 @@ def main():
     # Argparse Setting
     parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS,
                                      description='Terminal translator')
-    parser.add_argument('--clipboard', '-c', action='store_true',
+    parser.add_argument('-c', '--clipboard', action='store_true',
                         default=False, help='Using clipboard data.')
     parser.add_argument('data', default=None, nargs='*',
                         help='The text to query.')
-    parser.add_argument('--dumb', '-d', action='store_true',
+    parser.add_argument('-d', '--dumb', action='store_true',
                         default=False, help='No showing output data.')
     args = parser.parse_args()
 


### PR DESCRIPTION
* 클립보드를 사용할 수 없는 환경에서 클립보드의 내용을 번역시도시 아래의 에러 메세지를 보여주도록 했습니다. 일반적인 입력문자 번역은 기존과 같이 동작하며, 클립보드에 복사되지 못하도록 했습니다.
* 코드를 좀 더 고도화 시켜보았습니다. 
* 오타를 수정하였습니다.

```bash
python translate.py --clipboard 
usage: translate.py [-h] [-c] [-d] [data [data ...]]
translate.py: error:
    This error should only appear on Linux (not Windows or Mac).
    You can fix this by installing one of the copy/paste mechanisms:

    sudo apt-get install xsel to install the xsel utility.
    sudo apt-get install xclip to install the xclip utility.
    pip install gtk to install the gtk Python module.
    pip install PyQt4 to install the PyQt4 Python module.
```